### PR TITLE
Optimization: don't call Math.floor if already 60

### DIFF
--- a/src/js/justice.collectors.js
+++ b/src/js/justice.collectors.js
@@ -53,7 +53,7 @@ function trackFPS(time) {
   } else {
     var delta = (time - dataFpsLastTime) / 1000;
     var fps = 1 / delta;
-    var fpsClipped = Math.floor(fps > 60 ? 60 : fps);
+    var fpsClipped = fps > 60 ? 60 : Math.floor(fps);
     dataFpsCurrent = fpsClipped;
     dataFpsHistory.push([fpsClipped, fpsClipped]);
     if (dataFpsHistory.length > maxHistory) {


### PR DESCRIPTION
Since trackFPS is potentially being called every frame, I believe that not calling Math.floor when it is already 60 can give a fairly non-trivial optimization.